### PR TITLE
Bump dependencies

### DIFF
--- a/me.sanchezrodriguez.passes.json
+++ b/me.sanchezrodriguez.passes.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "me.sanchezrodriguez.passes",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "passes",
     "finish-args" : [

--- a/modules/blueprint.json
+++ b/modules/blueprint.json
@@ -5,7 +5,7 @@
         {
             "type": "git",
             "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-            "tag": "v0.12.0"
+            "tag": "v0.14.0"
         }
     ],
     "cleanup": [


### PR DESCRIPTION
This PR bumps dependencies:

- it updates blueprint-compiler to 0.14.0
- it updates the GNOME runtime 47

I have used this for a bit and found no issues. Hope it helps!