### PR TITLE
Update app, modules and Gnome SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build-dir/
+.flatpak-builder/
+repo/
+*~
+me.sanchezrodriguez.passes.flatpak

--- a/me.sanchezrodriguez.passes.json
+++ b/me.sanchezrodriguez.passes.json
@@ -38,6 +38,10 @@
                     "url" : "https://github.com/pablo-s/passes.git",
                     "tag" : "v0.10",
                     "commit" : "cbd32c0d2d5e8d5e4e385187bb08bd3581ebb3c9",
+                    "x-checker-data": {
+                      "type": "git",
+                      "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ]
         }

--- a/me.sanchezrodriguez.passes.json
+++ b/me.sanchezrodriguez.passes.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "me.sanchezrodriguez.passes",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "passes",
     "finish-args" : [
@@ -35,9 +35,9 @@
             "sources" : [
                 {
                     "type" : "git",
+                    "url" : "https://github.com/pablo-s/passes.git",
                     "tag" : "v0.10",
                     "commit" : "cbd32c0d2d5e8d5e4e385187bb08bd3581ebb3c9",
-                    "url" : "https://github.com/pablo-s/passes.git"
                 }
             ]
         }

--- a/me.sanchezrodriguez.passes.json
+++ b/me.sanchezrodriguez.passes.json
@@ -1,49 +1,49 @@
 {
-    "app-id" : "me.sanchezrodriguez.passes",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
-    "sdk" : "org.gnome.Sdk",
-    "command" : "passes",
-    "finish-args" : [
-        "--share=network",
-        "--share=ipc",
-        "--socket=fallback-x11",
-        "--device=dri",
-        "--socket=wayland"
-    ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
-    "cleanup-commands" : [
-        "find /app -type d -name blueprintcompiler | xargs rm -fr"
-    ],
-    "modules" : [
-        "modules/blueprint.json",
-        "modules/zint.json",
+  "app-id": "me.sanchezrodriguez.passes",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "48",
+  "sdk": "org.gnome.Sdk",
+  "command": "passes",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--socket=wayland"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "cleanup-commands": [
+    "find /app -type d -name blueprintcompiler | xargs rm -fr"
+  ],
+  "modules": [
+    "modules/blueprint.json",
+    "modules/zint.json",
+    {
+      "name": "passes",
+      "builddir": true,
+      "buildsystem": "meson",
+      "sources": [
         {
-            "name" : "passes",
-            "builddir" : true,
-            "buildsystem" : "meson",
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://github.com/pablo-s/passes.git",
-                    "tag" : "v0.10",
-                    "commit" : "cbd32c0d2d5e8d5e4e385187bb08bd3581ebb3c9",
-                    "x-checker-data": {
-                      "type": "git",
-                      "tag-pattern": "^v([\\d.]+)$"
-                    }
-                }
-            ]
+          "type": "git",
+          "url": "https://github.com/pablo-s/passes.git",
+          "tag": "v0.10",
+          "commit": "cbd32c0d2d5e8d5e4e385187bb08bd3581ebb3c9",
+          "x-checker-data": {
+            "type": "git",
+            "tag-pattern": "^v([\\d.]+)$"
+          }
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/modules/blueprint.json
+++ b/modules/blueprint.json
@@ -1,19 +1,19 @@
 {
-    "name": "blueprint-compiler",
-    "buildsystem": "meson",
-    "sources": [
-        {
-            "type": "git",
-            "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-            "tag": "v0.16.0",
-            "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0",
-            "x-checker-data": {
-              "type": "git",
-              "tag-pattern": "^v([\\d.]+)$"
-            }
-        }
-    ],
-    "cleanup": [
-        "*"
-    ]
+  "name": "blueprint-compiler",
+  "buildsystem": "meson",
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
+      "tag": "v0.16.0",
+      "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0",
+      "x-checker-data": {
+        "type": "git",
+        "tag-pattern": "^v([\\d.]+)$"
+      }
+    }
+  ],
+  "cleanup": [
+    "*"
+  ]
 }

--- a/modules/blueprint.json
+++ b/modules/blueprint.json
@@ -6,7 +6,11 @@
             "type": "git",
             "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
             "tag": "v0.16.0",
-            "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0"
+            "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0",
+            "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^v([\\d.]+)$"
+            }
         }
     ],
     "cleanup": [

--- a/modules/blueprint.json
+++ b/modules/blueprint.json
@@ -5,7 +5,8 @@
         {
             "type": "git",
             "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-            "tag": "v0.12.0"
+            "tag": "v0.16.0",
+            "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0"
         }
     ],
     "cleanup": [

--- a/modules/zint.json
+++ b/modules/zint.json
@@ -1,19 +1,19 @@
 {
-    "name": "zint",
-    "buildsystem": "cmake",
-    "sources": [
-        {
-            "type": "git",
-            "url": "https://github.com/zint/zint.git",
-            "tag" : "2.15.0",
-            "commit" : "4896136bdbebb1a0908a5cc419513efa5bf4bf70",
-            "x-checker-data": {
-              "type": "git",
-              "tag-pattern": "^([\\d.]+)$"
-            }
-        }
-    ],
-    "cleanup": [
-        "/bin/zint"
-    ]
+  "name": "zint",
+  "buildsystem": "cmake",
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/zint/zint.git",
+      "tag": "2.15.0",
+      "commit": "4896136bdbebb1a0908a5cc419513efa5bf4bf70",
+      "x-checker-data": {
+        "type": "git",
+        "tag-pattern": "^([\\d.]+)$"
+      }
+    }
+  ],
+  "cleanup": [
+    "/bin/zint"
+  ]
 }

--- a/modules/zint.json
+++ b/modules/zint.json
@@ -4,9 +4,9 @@
     "sources": [
         {
             "type": "git",
-            "tag" : "2.13.0",
-            "commit" : "a9b526be08bfe9891bdec87dbb9bf11b3b56e5d9",
-            "url": "https://github.com/zint/zint.git"
+            "url": "https://github.com/zint/zint.git",
+            "tag" : "2.15.0",
+            "commit" : "4896136bdbebb1a0908a5cc419513efa5bf4bf70"
         }
     ],
     "cleanup": [

--- a/modules/zint.json
+++ b/modules/zint.json
@@ -6,7 +6,11 @@
             "type": "git",
             "url": "https://github.com/zint/zint.git",
             "tag" : "2.15.0",
-            "commit" : "4896136bdbebb1a0908a5cc419513efa5bf4bf70"
+            "commit" : "4896136bdbebb1a0908a5cc419513efa5bf4bf70",
+            "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^([\\d.]+)$"
+            }
         }
     ],
     "cleanup": [


### PR DESCRIPTION
This PR updates:

  * the project to v0.10,
  * the GNOME SDK to 48,
  * the blueprint-compiler module to v0.16.0
  * and the zint module to 2.15.0

The PR also adds an x-checker for the app and every module.

This PR will also fix #7 and #8.